### PR TITLE
fix: node-addon-api exception handling

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,20 +2,17 @@
   "targets": [
     {
       "target_name": "crypt32",
-      "cflags!": [
-        "-fno-exceptions"
-      ],
-      "cflags_cc!": [
-        "-fno-exceptions"
-      ],
       "sources": [
         "crypt32.cc"
+      ],
+      "dependencies": [
+        "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except"
       ],
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
       "defines": [
-        "NAPI_DISABLE_CPP_EXCEPTIONS"
+        "NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS"
       ],
       "link_settings": {
         "libraries": ["-lcrypt32"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/windows-ca-certs",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/windows-ca-certs",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "BSD",
       "os": [
         "win32"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/windows-ca-certs",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Get Windows System Root certificates",
   "os": [
     "win32"


### PR DESCRIPTION
Properly defines exception handling story, see https://github.com/nodejs/node-addon-api/blob/main/doc/error_handling.md for context